### PR TITLE
Switch PCL profiles to 328

### DIFF
--- a/YAMP.Physics/YAMP.Portable.Physics.csproj
+++ b/YAMP.Physics/YAMP.Portable.Physics.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>YAMP.Portable.Physics</RootNamespace>
     <AssemblyName>YAMP.Portable.Physics</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile136</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <FileUpgradeFlags>

--- a/YAMP/YAMP.Portable.csproj
+++ b/YAMP/YAMP.Portable.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>YAMP.Portable</RootNamespace>
     <AssemblyName>YAMP.Portable</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile136</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <FileUpgradeFlags>


### PR DESCRIPTION
Hi Florian,

I just noticed that you were using PCL profile 136 in the *Portable* projects. There is an even wider-reaching profile, namely 328, which includes all the targets of 136 *plus* Windows Phone 8.1 (non-Silverlight).

I have successfully updated the PCL profile locally, so I thought I'd share the change with you. It is a minimal change, I know, but I hope you'll find it satisfactory nevertheless.

Best regards,
Anders