### PR TITLE
Fixed accessing uninitialized variable _default in ParseContext.ParseCon...

### DIFF
--- a/YAMP/ParseContext.cs
+++ b/YAMP/ParseContext.cs
@@ -92,7 +92,7 @@ namespace YAMP
         /// Creates a new (fresh) context with the default context as parent.
         /// </summary>
         public ParseContext() 
-            : this(_default)
+            : this(Default)
         {
         }
 


### PR DESCRIPTION
The deault constructor of `ParseContext` accessed an static filed which might be uninitialized. 